### PR TITLE
move notebook-requirements to setup.cfg

### DIFF
--- a/notebook-requirements.txt
+++ b/notebook-requirements.txt
@@ -1,7 +1,0 @@
-jupyter
-jupytext
-ipysheet
-nilearn
-ipywidgets
-traitlets
-pandas==0.23.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,14 @@ install_requires =
     #neurolang @ git+ssh://git@github.com/NeuroLang/NeuroLang@c6b2cfed2bce1c67f2f3e17f6669a8c6430f2bd3#egg=neurolang
     neurolang-ipywidgets @ git+ssh://git@github.com/NeuroLang/neurolang-ipywidgets#egg=neurolang-ipywidgets
     neurolang @ git+ssh://git@github.com/tgy/NeuroLang@d1e6ca8eb446da36e6a459e1c38cdebb92f93ddb#egg=neurolang
+    jupyter
+    jupytext
+    ipysheet
+    nilearn
+    ipywidgets
+    traitlets
+    pandas==0.23.4
+    voila
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Since this package will be dependent on the notebook environment (and not simply have notebook examples), move jupyter-related requirements into `setup.cfg`