### PR TITLE
fetch dependencies over https

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,8 @@ url = https://github.com/NeuroLang/neurolang_web
 [options]
 install_requires =
     #neurolang @ git+ssh://git@github.com/NeuroLang/NeuroLang@c6b2cfed2bce1c67f2f3e17f6669a8c6430f2bd3#egg=neurolang
-    neurolang-ipywidgets @ git+ssh://git@github.com/NeuroLang/neurolang-ipywidgets#egg=neurolang-ipywidgets
-    neurolang @ git+ssh://git@github.com/tgy/NeuroLang@d1e6ca8eb446da36e6a459e1c38cdebb92f93ddb#egg=neurolang
+    neurolang-ipywidgets @ git+https://github.com/NeuroLang/neurolang-ipywidgets.git#egg=neurolang-ipywidgets
+    neurolang @ git+https://github.com/tgy/NeuroLang.git@d1e6ca8eb446da36e6a459e1c38cdebb92f93ddb#egg=neurolang
     jupyter
     jupytext
     ipysheet


### PR DESCRIPTION
Fetch dependencies over https since we will need to pass an access token (e.g. PAT) for the examples gallery install.
