### PR TITLE
[WIP] Display errors in a section of the query widget 

### DIFF
--- a/nlweb/viewers/query.py
+++ b/nlweb/viewers/query.py
@@ -226,7 +226,7 @@ class QueryWidget(VBox):
         try:
             line_info = pe.tokenizer.line_info(pe.pos)
         except AttributeError:
-            # support tasu 4.x
+            # support tatsu 4.x
             line_info = pe.buf.line_info(pe.pos)
 
         self.query.marks = [{"line": line_info.line, "text": pe.message}]


### PR DESCRIPTION
(references issue #5)

Opening a WIP PR for discussion. A possible improvement would be to handle parse errors differently (e.g. change the current textarea to a codemirror-based widget and show error marks...)